### PR TITLE
ci: auto-rebuild dist/ on dependabot npm PRs

### DIFF
--- a/.github/workflows/dependabot-rebuild-dist.yml
+++ b/.github/workflows/dependabot-rebuild-dist.yml
@@ -1,0 +1,47 @@
+name: Rebuild dist for Dependabot
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild-dist:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Rebuild dist
+        run: |
+          npm run build
+          npm run package
+
+      - name: Commit rebuilt dist
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          if git diff --staged --quiet; then
+            echo "No dist changes to commit"
+          else
+            git commit -m "chore: rebuild dist for dependabot dependency updates"
+            git push
+          fi


### PR DESCRIPTION
Dependabot bumps package.json/package-lock.json but never regenerates
dist/, causing the check-dist CI job to fail. This workflow runs
npm install && npm run build && npm run package on dependabot PRs and
commits the updated dist/ back to the branch, replacing the manual
steps that appeared in past commits.

Uses pull_request_target (not pull_request) so the job gets a
write-capable GITHUB_TOKEN; guarded by github.actor == 'dependabot[bot]'.